### PR TITLE
Fix #65

### DIFF
--- a/src/Russian/LastNamesInflection.php
+++ b/src/Russian/LastNamesInflection.php
@@ -36,10 +36,14 @@ class LastNamesInflection extends \morphos\NamesInflection implements Cases
         if (in_array(S::slice($name, -1), ['а', 'я'], true)) {
             return true;
         }
+        
+        // Несклоняемые фамилии независимо от пола (Токаревских)
+        if (in_array(S::slice($name, -2), ['их'], true))
+            return false;
 
         if ($gender == static::MALE) {
-            // Несклоняемые фамилии (Фоминых, Седых / Стецко, Писаренко / Токаревских)
-            if (in_array(S::slice($name, -2), ['ых', 'ко', 'их'], true))
+            // Несклоняемые фамилии (Фоминых, Седых / Стецко, Писаренко)
+            if (in_array(S::slice($name, -2), ['ых', 'ко'], true))
                 return false;
 
             // Несклоняемые, образованные из родительного падежа личного или прозвищного имени главы семьи

--- a/src/Russian/LastNamesInflection.php
+++ b/src/Russian/LastNamesInflection.php
@@ -38,8 +38,8 @@ class LastNamesInflection extends \morphos\NamesInflection implements Cases
         }
 
         if ($gender == static::MALE) {
-            // Несклоняемые фамилии (Фоминых, Седых / Стецко, Писаренко)
-            if (in_array(S::slice($name, -2), ['ых', 'ко'], true))
+            // Несклоняемые фамилии (Фоминых, Седых / Стецко, Писаренко / Токаревских)
+            if (in_array(S::slice($name, -2), ['ых', 'ко', 'их'], true))
                 return false;
 
             // Несклоняемые, образованные из родительного падежа личного или прозвищного имени главы семьи


### PR DESCRIPTION
#65
Окончание фамилий `их ` несклоняемое (например [Бараковских](http://morphos.io/try/names?input=%D0%91%D0%B0%D1%80%D0%B0%D0%BA%D0%BE%D0%B2%D1%81%D0%BA%D0%B8%D1%85+%D0%91%D0%BE%D1%80%D0%B8%D1%81+%D0%94%D0%BC%D0%B8%D1%82%D1%80%D0%B8%D0%B5%D0%B2%D0%B8%D1%87), [Нарбутовских](http://morphos.io/try/names?input=%D0%9D%D0%B0%D1%80%D0%B1%D1%83%D1%82%D0%BE%D0%B2%D1%81%D0%BA%D0%B8%D1%85+%D0%92%D0%B8%D0%BA%D1%82%D0%BE%D1%80+%D0%93%D0%B5%D0%BD%D0%BD%D0%B0%D0%B4%D1%8C%D0%B5%D0%B2%D0%B8%D1%87) и [Токаревских](http://morphos.io/try/names?input=%D0%A2%D0%BE%D0%BA%D0%B0%D1%80%D0%B5%D0%B2%D1%81%D0%BA%D0%B8%D1%85+%D0%90%D0%BD%D1%82%D0%BE%D0%BD+%D0%93%D1%80%D0%B8%D0%B3%D0%BE%D1%80%D1%8C%D0%B5%D0%B2%D0%B8%D1%87))