### PR TITLE
Fix #65 pt.2

### DIFF
--- a/src/Russian/LastNamesInflection.php
+++ b/src/Russian/LastNamesInflection.php
@@ -191,7 +191,7 @@ class LastNamesInflection extends \morphos\NamesInflection implements Cases
                 $prefix = S::name(S::slice($name, 0, -1));
                 return [
                     static::IMENIT => S::name($name),
-                    static::RODIT => $prefix.(static::isDeafConsonant(S::slice($name, -2, -1)) ? 'и' : 'ы'),
+                    static::RODIT => $prefix.(static::isSonorousConsonant(S::slice($name, -2, -1)) ? 'и' : 'ы'),
                     static::DAT => $prefix.'е',
                     static::VINIT => $prefix.'у',
                     static::TVORIT => $prefix.'ой',


### PR DESCRIPTION
#65 
Фамилия [Прожога](http://morphos.io/try/names?input=%D0%9F%D1%80%D0%BE%D0%B6%D0%BE%D0%B3%D0%B0+%D0%90%D0%BD%D0%B4%D1%80%D0%B5%D0%B9+%D0%90%D0%BB%D0%B5%D0%BA%D1%81%D0%B0%D0%BD%D0%B4%D1%80%D0%BE%D0%B2%D0%B8%D1%87) при склонении в родительском роде получается Прожог`ы`, хотя должна быть Прожог`и`

При звонкой последней согласной `и` при глухой `ы`
Прожога -> Прожоги
Прожофа -> Прожофы