### PR TITLE
Добавлено географическое название Гоа в исключение

### DIFF
--- a/src/Russian/GeographicalNamesInflection.php
+++ b/src/Russian/GeographicalNamesInflection.php
@@ -31,7 +31,8 @@ class GeographicalNamesInflection extends \morphos\BaseInflection implements Cas
     protected static $immutableNames = [
         'алматы',
         'сочи',
-
+        'гоа',
+        
         // части
         'санкт',
         'йошкар',


### PR DESCRIPTION
Гоа не склоняется