### PR TITLE
Update MoneySpeller.php

### DIFF
--- a/src/Russian/MoneySpeller.php
+++ b/src/Russian/MoneySpeller.php
@@ -45,7 +45,10 @@ class MoneySpeller extends \morphos\MoneySpeller
         $currency = static::canonizeCurrency($currency);
 
         $integer = floor($value);
-        $fractional = floor(($value * 100) % 100);
+        // $fractional = floor(($value * 100) % 100);
+        $fractional = fmod($value, $integer);
+        $fractional = round($fractional, 2, PHP_ROUND_HALF_UP);
+        $fractional = $fractional * 100;
 
         switch ($format) {
             case static::SHORT_FORMAT:


### PR DESCRIPTION
fix problem http://sandbox.onlinephpfunctions.com/code/124c95f5bcd92df16f851ca3ffaaea873fa8a4e9

случайно обнаружена проблема с числом 65536.40
выдает текст 39 копеек
баг воспроизводится именно с числом в 40 копеек, когда целая часть больше 65536 и меньше 80000

методом тыка выяснилось следующее
баг повторяется в некотором диапазоне при пересечении байтовой границы хранения числа
т.е. баг повторяется с числами:
256.4 - пересекли границу 1 байт
65536.4 - пересекли границу 2 байта
16777216.4 - пересекли границу 3 байта
4294967296.4 - пересекли границу 4 байта

проблема где то в недрах php
моя правка решает эту проблему