### PR TITLE
Fix the types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ env:
 matrix:
   fast_finish: true
   include:
+    - php: 7.4
+      env: RUN_PHPSTAN=1
     - php: 7.3
     - php: 7.2
     # run tests coverage on PHP 7.1
@@ -37,6 +39,11 @@ install:
 
 script:
 - vendor/bin/phpunit $PHPUNIT_FLAGS
+- |
+  if [ $RUN_PHPSTAN == 1 ]; then
+    composer require --dev phpstan/phpstan
+    vendor/bin/phpstan analyse
+  fi
 
 after_script:
   - |

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,24 @@
+parameters:
+    level: 6
+    reportUnmatchedIgnoredErrors: false
+    paths:
+        - src
+        - tests
+    ignoreErrors:
+        -
+            message: '#Method .* has no return typehint specified#'
+            path: tests/
+        -
+            message: '#Method .* has parameter .* with no typehint specified#'
+            path: tests/
+        -
+            message: '#Method .* has parameter .* with no value type specified in iterable type array#'
+            path: tests/
+        -
+            message: '#Method .* return type has no value type specified in iterable type array#'
+            path: tests/
+        -
+            message: '#PHPDoc tag @param has invalid value \(.*\): Unexpected token ".*", expected type at offset .*#'
+            path: tests/
+        - '#Call to static method .* on trait .*#'
+        - '#Access to static property .* on trait .*#'

--- a/src/BaseInflection.php
+++ b/src/BaseInflection.php
@@ -1,17 +1,36 @@
 <?php
 namespace morphos;
 
+use RuntimeException;
+
 abstract class BaseInflection implements Cases
 {
-    public static function isMutable($name)
-    {
+    /**
+     * @abstract
+     * @param string $name
+     * @return bool
+     */
+    public static function isMutable($name) {
+        throw new RuntimeException('Not implemented');
     }
 
-    public static function getCases($name)
-    {
+    /**
+     * @abstract
+     * @param string $name
+     * @return string[]
+     * @phpstan-return array<string, string>
+     */
+    public static function getCases($name) {
+        throw new RuntimeException('Not implemented');
     }
 
-    public static function getCase($name, $case)
-    {
+    /**
+     * @abstract
+     * @param string $name
+     * @param string $case
+     * @return string
+     */
+    public static function getCase($name, $case) {
+        throw new RuntimeException('Not implemented');
     }
 }

--- a/src/BasePluralization.php
+++ b/src/BasePluralization.php
@@ -1,17 +1,42 @@
 <?php
 namespace morphos;
 
+use RuntimeException;
+
 abstract class BasePluralization
 {
-    public static function pluralize($word, $count = 2)
-    {
+    /**
+     * @abstract
+     * @param string $word
+     * @param int $count
+     *
+     * @return string
+     */
+    public static function pluralize($word, $count = 2) {
+        throw new RuntimeException('Not implemented');
     }
 
-    public static function getCase($word, $case, $animateness = false)
-    {
+    /**
+     * @abstract
+     * @param string $word
+     * @param string $case
+     * @param bool $animateness
+     *
+     * @return string
+     */
+    public static function getCase($word, $case, $animateness = false) {
+        throw new RuntimeException('Not implemented');
     }
 
-    public static function getCases($word, $animateness = false)
-    {
+    /**
+     * @abstract
+     * @param string $word
+     * @param bool $animateness
+     *
+     * @return string[]
+     * @phpstan-return array<string, string>
+     */
+    public static function getCases($word, $animateness = false) {
+        throw new RuntimeException('Not implemented');
     }
 }

--- a/src/CasesHelper.php
+++ b/src/CasesHelper.php
@@ -6,7 +6,7 @@ use InvalidArgumentException;
 trait CasesHelper
 {
     /**
-     * @param $case
+     * @param string $case
      * @return string
      * @throws InvalidArgumentException If passed case is invalid.
      */
@@ -49,7 +49,8 @@ trait CasesHelper
     }
 
     /**
-     * @return array
+     * @return string[]
+     * @phpstan-return array<\morphos\Cases::*>
      */
     public static function getAllCases()
     {
@@ -67,8 +68,10 @@ trait CasesHelper
     /**
      * Составляет один массив с падежами из нескольких массивов падежей разных слов
      * @param array $words Двумерный массив слов и их падежей
+     * @phpstan-param array<int, array<string, string>> $words
      * @param string $delimiter Разделитель между падежами слов
-     * @return array Одномерный массив падежей
+     * @return string[] Одномерный массив падежей
+     * @phpstan-return array<string, string>
      */
     public static function composeCasesFromWords(array $words, $delimiter = ' ') {
         $cases = [];

--- a/src/CurrenciesHelper.php
+++ b/src/CurrenciesHelper.php
@@ -6,7 +6,7 @@ use InvalidArgumentException;
 trait CurrenciesHelper
 {
     /**
-     * @param $currency
+     * @param string $currency
      * @return string
      * @throws InvalidArgumentException
      */

--- a/src/English/CardinalNumeralGenerator.php
+++ b/src/English/CardinalNumeralGenerator.php
@@ -2,9 +2,14 @@
 namespace morphos\English;
 
 use morphos\NumeralGenerator;
+use RuntimeException;
 
 class CardinalNumeralGenerator extends NumeralGenerator
 {
+    /**
+     * @var string[]
+     * @phpstan-var array<int, string>
+     */
     public static $words = [
         1 => 'one',
         2 => 'two',
@@ -35,24 +40,30 @@ class CardinalNumeralGenerator extends NumeralGenerator
         90 => 'ninety',
     ];
 
+    /**
+     * @var string[]
+     * @phpstan-var array<int, string>
+     */
     public static $exponents = [
-        '100' => 'hundred',
-        '1000' => 'thousand',
-        '1000000' => 'million',
-        '1000000000' => 'billion',
-        '1000000000000' => 'trillion',
+        100 => 'hundred',
+        1000 => 'thousand',
+        1000000 => 'million',
+        1000000000 => 'billion',
+        1000000000000 => 'trillion',
     ];
 
     public static function getCases($number)
     {
+        throw new RuntimeException('Not implemented');
     }
 
     public static function getCase($number, $case)
     {
+        throw new RuntimeException('Not implemented');
     }
 
     /**
-     * @param $number
+     * @param int $number
      * @return mixed|string
      */
     public static function generate($number)
@@ -68,7 +79,7 @@ class CardinalNumeralGenerator extends NumeralGenerator
 
             foreach (array_reverse(static::$exponents, true) as $word_number => $word) {
                 if ($number >= $word_number) {
-                    $count = floor($number / $word_number);
+                    $count = (int)floor($number / $word_number);
                     $number = $number % ($count * $word_number);
                     $parts[] = static::generate($count).' '.static::generate($word_number).($word_number != 100 && $number > 0 ? ',' : null);
                 }

--- a/src/English/NounPluralization.php
+++ b/src/English/NounPluralization.php
@@ -2,9 +2,14 @@
 namespace morphos\English;
 
 use morphos\S;
+use RuntimeException;
 
 class NounPluralization extends \morphos\BasePluralization
 {
+    /**
+     * @var string[]
+     * @phpstan-var array<string, string>
+     */
     private static $exceptions = [
         'chief' => 'chiefs',
         'basis' => 'bases',
@@ -22,6 +27,7 @@ class NounPluralization extends \morphos\BasePluralization
         'mouse' => 'mice'
     ];
 
+    /** @var string[]  */
     private static $without_paired_form = [
         'knowledge',
         'progress',
@@ -33,10 +39,11 @@ class NounPluralization extends \morphos\BasePluralization
         'trousers',
     ];
 
+    /** @var string[]  */
     public static $consonants = ['b', 'c', 'd', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n', 'p', 'q', 'r', 's', 't', 'v', 'x', 'z', 'w'];
 
     /**
-     * @param $word
+     * @param string $word
      * @param int $count
      * @return string
      */
@@ -68,5 +75,15 @@ class NounPluralization extends \morphos\BasePluralization
         } else {
             return $word.'s';
         }
+    }
+
+    public static function getCase($word, $case, $animateness = false)
+    {
+        throw new RuntimeException('Not implemented');
+    }
+
+    public static function getCases($word, $animateness = false)
+    {
+        throw new RuntimeException('Not implemented');
     }
 }

--- a/src/English/OrdinalNumeralGenerator.php
+++ b/src/English/OrdinalNumeralGenerator.php
@@ -2,9 +2,14 @@
 namespace morphos\English;
 
 use morphos\NumeralGenerator;
+use RuntimeException;
 
 class OrdinalNumeralGenerator extends NumeralGenerator
 {
+    /**
+     * @var string[]
+     * @phpstan-var array<int, string>
+     */
     protected static $words = [
         1 => 'first',
         2 => 'second',
@@ -17,13 +22,15 @@ class OrdinalNumeralGenerator extends NumeralGenerator
 
     public static function getCases($number)
     {
+        throw new RuntimeException('Not implemented');
     }
     public static function getCase($number, $case)
     {
+        throw new RuntimeException('Not implemented');
     }
 
     /**
-     * @param $number
+     * @param int $number
      * @param bool $short
      * @return string
      */
@@ -52,7 +59,7 @@ class OrdinalNumeralGenerator extends NumeralGenerator
 
             foreach (array_reverse(CardinalNumeralGenerator::$exponents, true) as $word_number => $word) {
                 if ($number >= $word_number) {
-                    $count = floor($number / $word_number);
+                    $count = (int)floor($number / $word_number);
                     $number = $number % ($count * $word_number);
                     $parts[] = CardinalNumeralGenerator::generate($count).' '.CardinalNumeralGenerator::generate($word_number).($word_number != 100 && $number > 0 ? ',' : null);
                 }

--- a/src/English/TimeSpeller.php
+++ b/src/English/TimeSpeller.php
@@ -5,6 +5,10 @@ use InvalidArgumentException;
 
 class TimeSpeller extends \morphos\TimeSpeller
 {
+    /**
+     * @var string[]
+     * @phpstan-var array<string, string>
+     */
     protected static $units = [
         self::YEAR => 'year',
         self::MONTH => 'month',
@@ -15,8 +19,8 @@ class TimeSpeller extends \morphos\TimeSpeller
     ];
 
     /**
-     * @param $count
-     * @param $unit
+     * @param int $count
+     * @param string $unit
      * @return string
      */
     public static function spellUnit($count, $unit)

--- a/src/MoneySpeller.php
+++ b/src/MoneySpeller.php
@@ -1,6 +1,8 @@
 <?php
 namespace morphos;
 
+use RuntimeException;
+
 abstract class MoneySpeller implements Currency
 {
     const SHORT_FORMAT = 'short';
@@ -11,15 +13,18 @@ abstract class MoneySpeller implements Currency
     /**
      * @abstract
      *
-     * @param float  $value
+     * @param float|int  $value
      * @param string $currency
      * @param string $format
-     * @param null   $case
+     * @param string|null   $case
+     * @return string
      */
     public static function spell(
         $value,
         $currency,
         $format = self::NORMAL_FORMAT,
         $case = null
-    ) {}
+    ) {
+        throw new RuntimeException('Not implemented');
+    }
 }

--- a/src/NamesInflection.php
+++ b/src/NamesInflection.php
@@ -1,15 +1,42 @@
 <?php
 namespace morphos;
 
+use RuntimeException;
+
 abstract class NamesInflection implements Cases, Gender
 {
-    public static function isMutable($name, $gender)
-    {
+    /**
+     * @abstract
+     * @param string $name
+     * @param string $gender
+     *
+     * @return bool
+     */
+    public static function isMutable($name, $gender) {
+        throw new RuntimeException('Not implemented');
     }
-    public static function getCases($name, $gender)
-    {
+
+    /**
+     * @abstract
+     * @param string $name
+     * @param string $gender
+     *
+     * @return string[]
+     * @phpstan-return array<string, string>
+     */
+    public static function getCases($name, $gender) {
+        throw new RuntimeException('Not implemented');
     }
-    public static function getCase($name, $case, $gender)
-    {
+
+    /**
+     * @abstract
+     * @param string $name
+     * @param string $case
+     * @param string|null $gender
+     *
+     * @return string
+     */
+    public static function getCase($name, $case, $gender) {
+        throw new RuntimeException('Not implemented');
     }
 }

--- a/src/NumeralGenerator.php
+++ b/src/NumeralGenerator.php
@@ -1,12 +1,29 @@
 <?php
 namespace morphos;
 
+use RuntimeException;
+
 abstract class NumeralGenerator implements Cases, Gender
 {
-    public static function getCases($number)
-    {
+    /**
+     * @abstract
+     * @param int $number
+     *
+     * @return string[]
+     * @phpstan-return array<string, string>
+     */
+    public static function getCases($number) {
+        throw new RuntimeException('Not implemented');
     }
-    public static function getCase($number, $case)
-    {
+
+    /**
+     * @abstract
+     * @param int $number
+     * @param string $case
+     *
+     * @return string
+     */
+    public static function getCase($number, $case) {
+        throw new RuntimeException('Not implemented');
     }
 }

--- a/src/Russian/AdjectiveDeclension.php
+++ b/src/Russian/AdjectiveDeclension.php
@@ -4,6 +4,7 @@ namespace morphos\Russian;
 use morphos\BaseInflection;
 use morphos\Gender;
 use morphos\S;
+use RuntimeException;
 
 /**
  * Class AdjectiveDeclension.
@@ -53,7 +54,7 @@ class AdjectiveDeclension extends BaseInflection implements Cases, Gender
     }
 
     /**
-     * @param      $adjective
+     * @param string $adjective
      *
      * @param bool $isEmphasized
      *
@@ -77,6 +78,8 @@ class AdjectiveDeclension extends BaseInflection implements Cases, Gender
             case 'ее':
                 return static::NEUTER;
         }
+
+        throw new RuntimeException('Unreachable');
     }
 
     /**
@@ -84,7 +87,8 @@ class AdjectiveDeclension extends BaseInflection implements Cases, Gender
      * @param bool $animateness
      * @param null|string $gender
      *
-     * @return array
+     * @return string[]
+     * @phpstan-return array<string, string>
      */
     public static function getCases($adjective, $animateness = false, $gender = null)
     {
@@ -109,10 +113,12 @@ class AdjectiveDeclension extends BaseInflection implements Cases, Gender
                 return static::declinateMixedAdjective($adjective, $animateness, $gender,
                     $last_consonant_vowel);
         }
+
+        throw new RuntimeException('Unreachable');
     }
 
     /**
-     * @param $adjective
+     * @param string $adjective
      *
      * @return int
      */
@@ -145,11 +151,10 @@ class AdjectiveDeclension extends BaseInflection implements Cases, Gender
      * @param string $adjective
      * @param bool   $animateness
      * @param string $gender
-     * @param bool   $isEmphasized
+     * @param string $afterConsonantVowel
      *
-     * @param        $afterConsonantVowel
-     *
-     * @return array
+     * @return string[]
+     * @phpstan-return array<string, string>
      */
     protected static function declinateHardAdjective($adjective, $animateness, $gender,
         $afterConsonantVowel)
@@ -167,6 +172,8 @@ class AdjectiveDeclension extends BaseInflection implements Cases, Gender
             case static::NEUTER:
                 $postfix = $afterConsonantVowel.'е';
                 break;
+
+            default: throw new RuntimeException('Unreachable');
         }
 
         $cases = [
@@ -190,11 +197,10 @@ class AdjectiveDeclension extends BaseInflection implements Cases, Gender
      * @param string $adjective
      * @param bool   $animateness
      * @param string $gender
-     * @param bool   $isEmphasized
+     * @param string $afterConsonantVowel
      *
-     * @param        $afterConsonantVowel
-     *
-     * @return array
+     * @return string[]
+     * @phpstan-return array<string, string>
      */
     protected static function declinateSoftAdjective($adjective, $animateness, $gender, $afterConsonantVowel)
     {
@@ -211,6 +217,8 @@ class AdjectiveDeclension extends BaseInflection implements Cases, Gender
             case static::NEUTER:
                 $postfix = $afterConsonantVowel.'е';
                 break;
+
+            default: throw new RuntimeException('Unreachable');
         }
 
         $cases = [
@@ -234,9 +242,10 @@ class AdjectiveDeclension extends BaseInflection implements Cases, Gender
      * @param string $adjective
      * @param bool   $animateness
      * @param string $gender
-     * @param bool   $isEmphasized
+     * @param string $afterConsonantVowel
      *
-     * @return array
+     * @return string[]
+     * @phpstan-return array<string, string>
      */
     protected static function declinateMixedAdjective($adjective, $animateness, $gender, $afterConsonantVowel)
     {
@@ -253,6 +262,8 @@ class AdjectiveDeclension extends BaseInflection implements Cases, Gender
             case static::NEUTER:
                 $postfix = $afterConsonantVowel.'е';
                 break;
+
+            default: throw new RuntimeException('Unreachable');
         }
 
         $cases = [

--- a/src/Russian/AdjectivePluralization.php
+++ b/src/Russian/AdjectivePluralization.php
@@ -3,16 +3,17 @@ namespace morphos\Russian;
 
 use morphos\BasePluralization;
 use morphos\S;
+use RuntimeException;
 
 class AdjectivePluralization extends BasePluralization implements Cases
 {
     use RussianLanguage, CasesHelper;
 
     /**
-     * @param      $adjective
+     * @param string $adjective
      * @param int  $count
      * @param bool $animateness
-     * @param null $case
+     * @param string|null $case
      *
      * @return string|void
      * @throws \Exception
@@ -20,6 +21,7 @@ class AdjectivePluralization extends BasePluralization implements Cases
     public static function pluralize($adjective, $count = 2, $animateness = false, $case = null)
     {
         // меняем местами аргументы, если они переданы в старом формате
+        // @phpstan-ignore-next-line
         if (is_string($count) && is_numeric($adjective)) {
             list($count, $adjective) = [$adjective, $count];
         }
@@ -45,11 +47,11 @@ class AdjectivePluralization extends BasePluralization implements Cases
     }
 
     /**
-     * @param      $adjective
-     * @param      $case
+     * @param string $adjective
+     * @param string $case
      * @param bool $animateness
      *
-     * @return
+     * @return string
      * @throws \Exception
      */
     public static function getCase($adjective, $case, $animateness = false)
@@ -60,10 +62,11 @@ class AdjectivePluralization extends BasePluralization implements Cases
     }
 
     /**
-     * @param      $adjective
+     * @param string $adjective
      * @param bool $animateness
      *
-     * @return array|void
+     * @return string[]
+     * @phpstan-return array<string, string>
      */
     public static function getCases($adjective, $animateness = false)
     {
@@ -100,5 +103,7 @@ class AdjectivePluralization extends BasePluralization implements Cases
 
                 return $cases;
         }
+
+        throw new RuntimeException('Unreachable');
     }
 }

--- a/src/Russian/CasesHelper.php
+++ b/src/Russian/CasesHelper.php
@@ -8,7 +8,7 @@ trait CasesHelper
     use \morphos\CasesHelper;
 
     /**
-     * @param $case
+     * @param string $case
      * @return string
      * @throws \Exception
      */

--- a/src/Russian/FirstNamesInflection.php
+++ b/src/Russian/FirstNamesInflection.php
@@ -11,6 +11,10 @@ class FirstNamesInflection extends \morphos\NamesInflection implements Cases
 {
     use RussianLanguage, CasesHelper;
 
+    /**
+     * @var string[][]
+     * @phpstan-var array<string, array<string, string>>
+     */
     protected static $exceptions = [
         'лев' => [
             self::IMENIT => 'Лев',
@@ -30,6 +34,7 @@ class FirstNamesInflection extends \morphos\NamesInflection implements Cases
         ]
     ];
 
+    /** @var string[]  */
     protected static $menNames = [
         'абрам', 'аверьян', 'авраам', 'агафон', 'адам', 'азар', 'акакий', 'аким', 'аксён', 'александр', 'алексей',
         'альберт', 'анатолий', 'андрей', 'андрон', 'антип', 'антон', 'аполлон', 'аристарх', 'аркадий', 'арнольд',
@@ -48,6 +53,7 @@ class FirstNamesInflection extends \morphos\NamesInflection implements Cases
         'эммануил', 'эраст', 'юлиан', 'юлий', 'юрий', 'яков', 'ян', 'ярослав',
     ];
 
+    /** @var string[]  */
     protected static $womenNames = [
         'авдотья', 'аврора', 'агата', 'агния', 'агриппина', 'ада', 'аксинья', 'алевтина', 'александра', 'алёна',
         'алена', 'алина', 'алиса', 'алла', 'альбина', 'амалия', 'анастасия', 'ангелина', 'анжела', 'анжелика', 'анна',
@@ -67,6 +73,7 @@ class FirstNamesInflection extends \morphos\NamesInflection implements Cases
         'ярослава',
     ];
 
+    /** @var string[]  */
     protected static $immutableNames = [
         'николя',
     ];
@@ -119,7 +126,7 @@ class FirstNamesInflection extends \morphos\NamesInflection implements Cases
     }
 
     /**
-     * @param $name
+     * @param string $name
      * @return string
      */
     public static function detectGender($name)
@@ -179,7 +186,8 @@ class FirstNamesInflection extends \morphos\NamesInflection implements Cases
     /**
      * @param string $name
      * @param null|string $gender
-     * @return array
+     * @return string[]
+     * @phpstan-return array<string, string>
      */
     public static function getCases($name, $gender = null)
     {
@@ -231,7 +239,8 @@ class FirstNamesInflection extends \morphos\NamesInflection implements Cases
 
     /**
      * @param string $name
-     * @return array|null
+     * @return string[]|null
+     * @phpstan-return array<string, string>|null
      */
     protected static function getCasesMan($name)
     {
@@ -309,7 +318,8 @@ class FirstNamesInflection extends \morphos\NamesInflection implements Cases
 
     /**
      * @param string $name
-     * @return array|null
+     * @return string[]|null
+     * @phpstan-return array<string, string>|null
      */
     protected static function getCasesWoman($name)
     {

--- a/src/Russian/GeographicalNamesInflection.php
+++ b/src/Russian/GeographicalNamesInflection.php
@@ -10,6 +10,7 @@ class GeographicalNamesInflection extends \morphos\BaseInflection implements Cas
 {
     use RussianLanguage, CasesHelper;
 
+    /** @var string[]  */
     protected static $abbreviations = [
         'сша',
         'оаэ',
@@ -17,6 +18,7 @@ class GeographicalNamesInflection extends \morphos\BaseInflection implements Cas
         'юар',
     ];
 
+    /** @var string[]  */
     protected static $delimiters = [
         ' ',
         '-на-',
@@ -28,11 +30,12 @@ class GeographicalNamesInflection extends \morphos\BaseInflection implements Cas
         '-',
     ];
 
+    /** @var string[]  */
     protected static $ovAbnormalExceptions = [
         'осташков',
     ];
 
-
+    /** @var string[]  */
     protected static $immutableNames = [
         'алматы',
         'сочи',
@@ -63,9 +66,9 @@ class GeographicalNamesInflection extends \morphos\BaseInflection implements Cas
         'эс',
         'сен',
         'ла',
-
     ];
 
+    /** @var string[]  */
     protected static $runawayVowelsExceptions = [
         'торжо*к',
         'волоче*к',
@@ -78,19 +81,23 @@ class GeographicalNamesInflection extends \morphos\BaseInflection implements Cas
         'черепове*ц',
     ];
 
+    /**
+     * @var string[]
+     * @phpstan-var array<string, string>
+     */
     protected static $misspellings = [
         'орел' => 'орёл',
         'рублево' => 'рублёво',
     ];
 
     /**
-     * @return array|bool
+     * @return int[]|false[]
      */
     protected static function getRunAwayVowelsList()
     {
         $runawayVowelsNormalized = [];
         foreach (static::$runawayVowelsExceptions as $word) {
-            $runawayVowelsNormalized[str_replace('*', null, $word)] = S::indexOf($word, '*') - 1;
+            $runawayVowelsNormalized[str_replace('*', '', $word)] = S::indexOf($word, '*') - 1;
         }
         return $runawayVowelsNormalized;
     }
@@ -141,7 +148,8 @@ class GeographicalNamesInflection extends \morphos\BaseInflection implements Cas
     /**
      * Получение всех форм названия
      * @param string $name
-     * @return array
+     * @return string[]
+     * @phpstan-return array<string, string>
      * @throws \Exception
      */
     public static function getCases($name)
@@ -492,6 +500,8 @@ class GeographicalNamesInflection extends \morphos\BaseInflection implements Cas
                 // ов, её, ...
                 elseif (in_array(S::slice($name, -2), $suffixes, true)) {
                     $prefix = S::name($name);
+                } else {
+                    $prefix = '';
                 }
 
                 return [
@@ -516,7 +526,7 @@ class GeographicalNamesInflection extends \morphos\BaseInflection implements Cas
     /**
      * Получение одной формы (падежа) названия.
      * @param string $name  Название
-     * @param integer $case Падеж. Одна из констант \morphos\Russian\Cases или \morphos\Cases.
+     * @param string $case Падеж. Одна из констант {@see \morphos\Russian\Cases} или {@see \morphos\Cases}.
      * @see \morphos\Russian\Cases
      * @return string
      * @throws \Exception

--- a/src/Russian/LastNamesInflection.php
+++ b/src/Russian/LastNamesInflection.php
@@ -10,12 +10,14 @@ class LastNamesInflection extends \morphos\NamesInflection implements Cases
 {
     use RussianLanguage, CasesHelper;
 
-    protected static $menPostfixes = ['ов', 'ев' ,'ин' ,'ын', 'ой', 'ий'];
+    /** @var string[] */
     protected static $womenPostfixes = ['ва', 'на', 'ая', 'яя'];
+    /** @var string[] */
+    protected static $menPostfixes = ['ов', 'ев' ,'ин' ,'ын', 'ой', 'ий'];
 
     /**
-     * @param $name
-     * @param null $gender
+     * @param string $name
+     * @param string|null $gender
      * @return bool
      */
     public static function isMutable($name, $gender = null)
@@ -77,7 +79,7 @@ class LastNamesInflection extends \morphos\NamesInflection implements Cases
     }
 
     /**
-     * @param $name
+     * @param string $name
      * @return null|string
      */
     public static function detectGender($name)
@@ -94,9 +96,10 @@ class LastNamesInflection extends \morphos\NamesInflection implements Cases
     }
 
     /**
-     * @param $name
+     * @param string $name
      * @param null|string $gender
-     * @return array
+     * @return string[]
+     * @phpstan-return array<string, string>
      */
     public static function getCases($name, $gender = null)
     {
@@ -230,8 +233,8 @@ class LastNamesInflection extends \morphos\NamesInflection implements Cases
     }
 
     /**
-     * @param $name
-     * @param $case
+     * @param string $name
+     * @param string $case
      * @param null $gender
      * @return string
      * @throws \Exception

--- a/src/Russian/MiddleNamesInflection.php
+++ b/src/Russian/MiddleNamesInflection.php
@@ -11,7 +11,7 @@ class MiddleNamesInflection extends \morphos\NamesInflection implements Cases
     use RussianLanguage, CasesHelper;
 
     /**
-     * @param $name
+     * @param string $name
      * @return null|string
      */
     public static function detectGender($name)
@@ -27,7 +27,7 @@ class MiddleNamesInflection extends \morphos\NamesInflection implements Cases
     }
 
     /**
-     * @param $name
+     * @param string $name
      * @param null $gender
      * @return bool
      */
@@ -43,10 +43,10 @@ class MiddleNamesInflection extends \morphos\NamesInflection implements Cases
     }
 
     /**
-     * @param $name
-     * @param $case
-     * @param null $gender
-     * @return mixed
+     * @param string $name
+     * @param string $case
+     * @param string|null $gender
+     * @return string
      * @throws \Exception
      */
     public static function getCase($name, $case, $gender = null)
@@ -57,9 +57,10 @@ class MiddleNamesInflection extends \morphos\NamesInflection implements Cases
     }
 
     /**
-     * @param $name
-     * @param null $gender
-     * @return array
+     * @param string $name
+     * @param string|null $gender
+     * @return string[]
+     * @phpstan-return array<string, string>
      */
     public static function getCases($name, $gender = null)
     {

--- a/src/Russian/MoneySpeller.php
+++ b/src/Russian/MoneySpeller.php
@@ -3,11 +3,16 @@ namespace morphos\Russian;
 
 use morphos\Gender;
 use morphos\CurrenciesHelper;
+use RuntimeException;
 
 class MoneySpeller extends \morphos\MoneySpeller
 {
     use CurrenciesHelper;
 
+    /**
+     * @var array[]
+     * @phpstan-var array<string, string[]>
+     */
     protected static $labels = [
         self::DOLLAR => ['доллар', Gender::MALE, 'цент', Gender::MALE],
         self::EURO => ['евро', Gender::NEUTER, 'цент', Gender::MALE],
@@ -30,7 +35,7 @@ class MoneySpeller extends \morphos\MoneySpeller
      * @param float|integer $value
      * @param string        $currency
      * @param string        $format
-     * @param null          $case
+     * @param string|null   $case
      *
      * @return string
      * @throws \Exception
@@ -44,10 +49,10 @@ class MoneySpeller extends \morphos\MoneySpeller
     {
         $currency = static::canonizeCurrency($currency);
 
-        $integer = floor($value);
+        $integer = (int)floor($value);
         $fractional = fmod($value, $integer);
         $fractional = round($fractional, 2);
-        $fractional *= 100;
+        $fractional = (int)($fractional * 100);
 
         switch ($format) {
             case static::SHORT_FORMAT:
@@ -82,5 +87,7 @@ class MoneySpeller extends \morphos\MoneySpeller
                         .NounPluralization::pluralize(static::$labels[$currency][2], $fractional, false, $case);
                 }
         }
+
+        throw new RuntimeException('Unreachable');
     }
 }

--- a/src/Russian/NounDeclension.php
+++ b/src/Russian/NounDeclension.php
@@ -4,6 +4,7 @@ namespace morphos\Russian;
 use morphos\BaseInflection;
 use morphos\Gender;
 use morphos\S;
+use RuntimeException;
 
 /**
  * Rules are from http://morpher.ru/Russian/Noun.aspx
@@ -16,6 +17,7 @@ class NounDeclension extends BaseInflection implements Cases, Gender
     const SECOND_DECLENSION = 2;
     const THIRD_DECLENSION = 3;
 
+    /** @var string[] */
     public static $immutableWords = [
         // валюты
         'евро', 'пенни', 'песо', 'сентаво',
@@ -38,6 +40,7 @@ class NounDeclension extends BaseInflection implements Cases, Gender
 
     /**
      * These words has 2 declension type.
+     * @var string[]|string[][]
      */
     protected static $abnormalExceptions = [
         'бремя',
@@ -55,6 +58,7 @@ class NounDeclension extends BaseInflection implements Cases, Gender
         'дитя' => ['дитя', 'дитяти', 'дитяти', 'дитя', 'дитятей', 'дитяти'],
     ];
 
+    /** @var string[]  */
     protected static $masculineWithSoft = [
         'автослесарь',
         'библиотекарь',
@@ -98,6 +102,7 @@ class NounDeclension extends BaseInflection implements Cases, Gender
         'ячмень',
     ];
 
+    /** @var string[]  */
     protected static $masculineWithSoftAndRunAwayVowels = [
         'день',
         'пень',
@@ -144,7 +149,7 @@ class NounDeclension extends BaseInflection implements Cases, Gender
 
     /**
      * Определение склонения (по школьной программе) существительного.
-     * @param $word
+     * @param string $word
      * @param bool $animateness
      * @return int
      */
@@ -171,7 +176,8 @@ class NounDeclension extends BaseInflection implements Cases, Gender
      * Получение слова во всех 6 падежах.
      * @param string $word
      * @param bool $animateness Признак одушевлённости
-     * @return array
+     * @return string[]
+     * @phpstan-return array<string, string>
      */
     public static function getCases($word, $animateness = false)
     {
@@ -192,9 +198,13 @@ class NounDeclension extends BaseInflection implements Cases, Gender
                 static::TVORIT => $word,
                 static::PREDLOJ => $word,
             ];
-        } elseif (isset(static::$abnormalExceptions[$word])) {
+        }
+
+        if (isset(static::$abnormalExceptions[$word])) {
             return array_combine([static::IMENIT, static::RODIT, static::DAT, static::VINIT, static::TVORIT, static::PREDLOJ], static::$abnormalExceptions[$word]);
-        } elseif (in_array($word, static::$abnormalExceptions, true)) {
+        }
+
+        if (in_array($word, static::$abnormalExceptions, true)) {
             $prefix = S::slice($word, 0, -1);
             return [
                 static::IMENIT => $word,
@@ -213,13 +223,16 @@ class NounDeclension extends BaseInflection implements Cases, Gender
                 return static::declinateSecondDeclension($word, $animateness);
             case static::THIRD_DECLENSION:
                 return static::declinateThirdDeclension($word);
+
+            default: throw new RuntimeException('Unreachable');
         }
     }
 
     /**
      * Получение всех форм слова первого склонения.
-     * @param $word
-     * @return array
+     * @param string $word
+     * @return string[]
+     * @phpstan-return array<string, string>
      */
     public static function declinateFirstDeclension($word)
     {
@@ -259,9 +272,10 @@ class NounDeclension extends BaseInflection implements Cases, Gender
 
     /**
      * Получение всех форм слова второго склонения.
-     * @param $word
+     * @param string $word
      * @param bool $animateness
-     * @return array
+     * @return string[]
+     * @phpstan-return array<string, string>
      */
     public static function declinateSecondDeclension($word, $animateness = false)
     {
@@ -320,8 +334,9 @@ class NounDeclension extends BaseInflection implements Cases, Gender
 
     /**
      * Получение всех форм слова третьего склонения.
-     * @param $word
-     * @return array
+     * @param string $word
+     * @return string[]
+     * @phpstan-return array<string, string>
      */
     public static function declinateThirdDeclension($word)
     {
@@ -340,9 +355,10 @@ class NounDeclension extends BaseInflection implements Cases, Gender
     /**
      * Склонение существительных, образованных от прилагательных и причастий.
      * Rules are from http://rusgram.narod.ru/1216-1231.html
-     * @param $word
-     * @param $animateness
-     * @return array
+     * @param string $word
+     * @param bool $animateness
+     * @return string[]
+     * @phpstan-return array<string, string>
      */
     public static function declinateAdjective($word, $animateness)
     {
@@ -395,13 +411,15 @@ class NounDeclension extends BaseInflection implements Cases, Gender
                     Cases::TVORIT => $prefix.$ending,
                     Cases::PREDLOJ => $prefix.$ending,
                 ];
+
+            default: throw new RuntimeException('Unreachable');
         }
     }
 
     /**
      * Получение одной формы слова (падежа).
      * @param string $word Слово
-     * @param integer $case Падеж
+     * @param string $case Падеж
      * @param bool $animateness Признак одушевленности
      * @return string
      * @throws \Exception
@@ -414,9 +432,9 @@ class NounDeclension extends BaseInflection implements Cases, Gender
     }
 
     /**
-     * @param $word
-     * @param $last
-     * @return bool
+     * @param string $word
+     * @param string $last
+     * @return string
      */
     public static function getPrefixOfSecondDeclension($word, $last)
     {
@@ -440,9 +458,9 @@ class NounDeclension extends BaseInflection implements Cases, Gender
     }
 
     /**
-     * @param $word
-     * @param $last
-     * @param $prefix
+     * @param string $word
+     * @param string $last
+     * @param string $prefix
      * @return string
      */
     public static function getPredCaseOf12Declensions($word, $last, $prefix)

--- a/src/Russian/NounPluralization.php
+++ b/src/Russian/NounPluralization.php
@@ -14,15 +14,24 @@ class NounPluralization extends \morphos\BasePluralization implements Cases
     const TWO_FOUR = 2;
     const FIVE_OTHER = 3;
 
+    /**
+     * @var string[][]
+     * @phpstan-var array<string, string[]>
+     */
     protected static $abnormalExceptions = [
         'человек' => ['люди', 'человек', 'людям', 'людей', 'людьми', 'людях'],
     ];
 
+    /** @var string[] */
     protected static $neuterExceptions = [
         'поле',
         'море',
     ];
 
+    /**
+     * @var string[]
+     * @phpstan-var array<string, string>
+     */
     protected static $genitiveExceptions = [
         'письмо' => 'писем',
         'пятно' => 'пятен',
@@ -35,6 +44,7 @@ class NounPluralization extends \morphos\BasePluralization implements Cases
         'год' => 'лет',
     ];
 
+    /** @var string[] */
     protected static $runawayVowelsExceptions = [
         'писе*ц',
         'песе*ц',
@@ -42,13 +52,13 @@ class NounPluralization extends \morphos\BasePluralization implements Cases
     ];
 
     /**
-     * @return array|bool
+     * @return int[]|false[]
      */
     protected static function getRunAwayVowelsList()
     {
         $runawayVowelsNormalized = [];
         foreach (static::$runawayVowelsExceptions as $word) {
-            $runawayVowelsNormalized[str_replace('*', null, $word)] = S::indexOf($word, '*') - 1;
+            $runawayVowelsNormalized[str_replace('*', '', $word)] = S::indexOf($word, '*') - 1;
         }
         return $runawayVowelsNormalized;
     }
@@ -57,7 +67,7 @@ class NounPluralization extends \morphos\BasePluralization implements Cases
      * Склонение существительного для сочетания с числом (кол-вом предметов).
      *
      * @param string|int $word        Название предмета
-     * @param int|string $count       Количество предметов
+     * @param int|float|string $count Количество предметов
      * @param bool       $animateness Признак одушевленности
      * @param string     $case        Род существительного
      *
@@ -104,7 +114,7 @@ class NounPluralization extends \morphos\BasePluralization implements Cases
     }
 
     /**
-     * @param $count
+     * @param int|float $count
      * @return int
      */
     public static function getNumeralForm($count)
@@ -124,8 +134,8 @@ class NounPluralization extends \morphos\BasePluralization implements Cases
     }
 
     /**
-     * @param $word
-     * @param $case
+     * @param string $word
+     * @param string $case
      * @param bool $animateness
      * @return string
      * @throws \Exception
@@ -138,9 +148,10 @@ class NounPluralization extends \morphos\BasePluralization implements Cases
     }
 
     /**
-     * @param $word
+     * @param string $word
      * @param bool $animateness
-     * @return array
+     * @return string[]
+     * @phpstan-return array<string, string>
      */
     public static function getCases($word, $animateness = false)
     {
@@ -175,9 +186,10 @@ class NounPluralization extends \morphos\BasePluralization implements Cases
 
     /**
      * Склонение обычных существительных.
-     * @param $word
-     * @param $animateness
-     * @return array
+     * @param string $word
+     * @param bool $animateness
+     * @return string[]
+     * @phpstan-return array<string, string>
      */
     protected static function declinateSubstative($word, $animateness)
     {
@@ -268,9 +280,10 @@ class NounPluralization extends \morphos\BasePluralization implements Cases
     /**
      * Склонение существительных, образованных от прилагательных и причастий.
      * Rules are from http://rusgram.narod.ru/1216-1231.html
-     * @param $word
-     * @param $animateness
-     * @return array
+     * @param string $word
+     * @param bool $animateness
+     * @return string[]
+     * @phpstan-return array<string, string>
      */
     protected static function declinateAdjective($word, $animateness)
     {

--- a/src/Russian/RussianLanguage.php
+++ b/src/Russian/RussianLanguage.php
@@ -7,7 +7,7 @@ use morphos\S;
 trait RussianLanguage
 {
     /**
-     * @var array Все гласные
+     * @var string[] Все гласные
      */
     public static $vowels = [
         'а',
@@ -23,7 +23,7 @@ trait RussianLanguage
     ];
 
     /**
-     * @var array Все согласные
+     * @var string[] Все согласные
      */
     public static $consonants = [
         'б',
@@ -50,7 +50,8 @@ trait RussianLanguage
     ];
 
     /**
-     * @var array Пары согласных
+     * @var string[] Пары согласных
+     * @phpstan-var array<string, string>
      */
     public static $pairs = [
         'б' => 'п',
@@ -62,21 +63,21 @@ trait RussianLanguage
     ];
 
     /**
-     * @var array Звонкие согласные
+     * @var string[] Звонкие согласные
      */
     public static $sonorousConsonants = ['б', 'в', 'г', 'д', 'з', 'ж', 'л', 'м', 'н', 'р'];
     /**
-     * @var array Глухие согласные
+     * @var string[] Глухие согласные
      */
     public static $deafConsonants = ['п', 'ф', 'к', 'т', 'с', 'ш', 'х', 'ч', 'щ'];
 
     /**
-     * @var array Союзы
+     * @var string[] Союзы
      */
     public static $unions = ['и', 'или'];
 
     /**
-     * @return array
+     * @return string[]
      */
     public static function getVowels()
     {
@@ -85,7 +86,7 @@ trait RussianLanguage
 
     /**
      * Проверка гласной
-     * @param $char
+     * @param string $char
      * @return bool
      */
     public static function isVowel($char)
@@ -95,7 +96,7 @@ trait RussianLanguage
 
     /**
      * Проверка согласной
-     * @param $char
+     * @param string $char
      * @return bool
      */
     public static function isConsonant($char)
@@ -105,6 +106,8 @@ trait RussianLanguage
 
     /**
      * Проверка звонкости согласной
+     * @param string $char
+     * @return bool
      */
     public static function isSonorousConsonant($char)
     {
@@ -113,7 +116,7 @@ trait RussianLanguage
 
     /**
      * Проверка глухости согласной
-     * @param $char
+     * @param string $char
      * @return bool
      */
     public static function isDeafConsonant($char)
@@ -123,7 +126,7 @@ trait RussianLanguage
 
     /**
      * Щипящая ли согласная
-     * @param $consonant
+     * @param string $consonant
      * @return bool
      */
     public static function isHissingConsonant($consonant)
@@ -133,7 +136,7 @@ trait RussianLanguage
 
     /**
      * Проверка на велярность согласной
-     * @param string[1] $consonant
+     * @param string $consonant
      * @return bool
      */
     protected static function isVelarConsonant($consonant)
@@ -143,7 +146,7 @@ trait RussianLanguage
 
     /**
      * Подсчет слогов
-     * @param $string
+     * @param string $string
      * @return bool|int
      */
     public static function countSyllables($string)
@@ -154,7 +157,7 @@ trait RussianLanguage
     /**
      * Проверка парности согласной
      *
-     * @param $consonant
+     * @param string $consonant
      * @return bool
      */
     public static function isPairedConsonant($consonant)
@@ -165,7 +168,7 @@ trait RussianLanguage
 
     /**
      * Проверка мягкости последней согласной
-     * @param $word
+     * @param string $word
      * @return bool
      */
     public static function checkLastConsonantSoftness($word)
@@ -173,7 +176,9 @@ trait RussianLanguage
         if (($substring = S::findLastPositionForOneOfChars(S::lower($word), static::$consonants)) !== false) {
             if (in_array(S::slice($substring, 0, 1), ['й', 'ч', 'щ', 'ш'], true)) { // always soft consonants
                 return true;
-            } elseif (S::length($substring) > 1 && in_array(S::slice($substring, 1, 2), ['е', 'ё', 'и', 'ю', 'я', 'ь'], true)) { // consonants are soft if they are trailed with these vowels
+            }
+
+            if (S::length($substring) > 1 && in_array(S::slice($substring, 1, 2), ['е', 'ё', 'и', 'ю', 'я', 'ь'], true)) { // consonants are soft if they are trailed with these vowels
                 return true;
             }
         }
@@ -182,7 +187,7 @@ trait RussianLanguage
 
     /**
      * Проверка мягкости последней согласной, за исключением Н
-     * @param $word
+     * @param string $word
      * @return bool
      */
     public static function checkBaseLastConsonantSoftness($word)
@@ -194,7 +199,9 @@ trait RussianLanguage
         if (($substring = S::findLastPositionForOneOfChars(S::lower($word), $consonants)) !== false) {
             if (in_array(S::slice($substring, 0, 1), ['й', 'ч', 'щ', 'ш'], true)) { // always soft consonants
                 return true;
-            } elseif (S::length($substring) > 1 && in_array(S::slice($substring, 1, 2), ['е', 'ё', 'и', 'ю', 'я', 'ь'], true)) { // consonants are soft if they are trailed with these vowels
+            }
+
+            if (S::length($substring) > 1 && in_array(S::slice($substring, 1, 2), ['е', 'ё', 'и', 'ю', 'я', 'ь'], true)) { // consonants are soft if they are trailed with these vowels
                 return true;
             }
         }
@@ -203,7 +210,7 @@ trait RussianLanguage
 
     /**
      * Проверяет, что гласная образует два звука в словах
-     * @param $vowel
+     * @param string $vowel
      * @return bool
      */
     public static function isBinaryVowel($vowel)
@@ -224,28 +231,28 @@ trait RussianLanguage
     {
         if (in_array(S::lower(S::slice($word, 0, 1)), ['а', 'о', 'и', 'у', 'э'], true)) {
             return $prepositionWithVowel;
-        } else {
-            return $preposition;
         }
+
+        return $preposition;
     }
 
     /**
      * Выбор окончания в зависимости от мягкости
      *
-     * @param $last
-     * @param $softLast
-     * @param $afterSoft
-     * @param $afterHard
+     * @param string $last
+     * @param bool $softLast
+     * @param string $afterSoft
+     * @param string $afterHard
      *
-     * @return mixed
+     * @return string
      */
     public static function chooseVowelAfterConsonant($last, $softLast, $afterSoft, $afterHard)
     {
         if ($last !== 'щ' && /*static::isVelarConsonant($last) ||*/ $softLast) {
             return $afterSoft;
-        } else {
-            return $afterHard;
         }
+
+        return $afterHard;
     }
 
     /**
@@ -257,7 +264,7 @@ trait RussianLanguage
     {
         $verb = S::lower($verb);
         // возвратный глагол
-        if (S::slice($verb, -2) == 'ся') {
+        if (S::slice($verb, -2) === 'ся') {
 
             return ($gender == Gender::MALE
                 ? $verb
@@ -291,7 +298,7 @@ trait RussianLanguage
     public static function with($word)
     {
         $normalized = trim(S::lower($word));
-        if (in_array(S::slice($normalized, 0, 1), ['c', 'з', 'ш', 'ж'], true) && static::isConsonant(S::slice($normalized, 1, 2)) || S::slice($normalized, 0, 1) == 'щ')
+        if (in_array(S::slice($normalized, 0, 1), ['c', 'з', 'ш', 'ж'], true) && static::isConsonant(S::slice($normalized, 1, 2)) || S::slice($normalized, 0, 1) === 'щ')
             return 'со '.$word;
         return 'с '.$word;
     }
@@ -344,16 +351,17 @@ trait RussianLanguage
     }
 
     /**
-     * @param array $forms
-     * @param $animate
-     * @return mixed
+     * @param string[] $forms
+     * @phpstan-param array<string, string> $forms
+     * @param bool $animate
+     * @return string
      */
     public static function getVinitCaseByAnimateness(array $forms, $animate)
     {
         if ($animate) {
             return $forms[Cases::RODIT];
-        } else {
-            return $forms[Cases::IMENIT];
         }
+
+        return $forms[Cases::IMENIT];
     }
 }

--- a/src/Russian/TimeSpeller.php
+++ b/src/Russian/TimeSpeller.php
@@ -5,6 +5,9 @@ use InvalidArgumentException;
 
 class TimeSpeller extends \morphos\TimeSpeller
 {
+    /**
+     * @var string[]
+     */
     protected static $units = [
         self::YEAR => 'год',
         self::MONTH => 'месяц',
@@ -22,8 +25,8 @@ class TimeSpeller extends \morphos\TimeSpeller
     const JUST_NOW = 'только что';
 
     /**
-     * @param $count
-     * @param $unit
+     * @param int $count
+     * @param string $unit
      *
      * @return string
      * @throws \Exception

--- a/src/Russian/functions.php
+++ b/src/Russian/functions.php
@@ -54,7 +54,7 @@ function inflectName($fullName, $case = null, $gender = null)
  * @param string      $fullName Name in "F", "L F" or "L M F" format, where L - last name, M - middle name, F - first name
  * @param null|string $gender   Gender of name owner. If null, auto detection will be used.
  *                              Should be one of [[morphos\Gender]] constants.
- * @return array|false          Returns an array with name inflected to all cases.
+ * @return string[]|false          Returns an array with name inflected to all cases.
  */
 function getNameCases($fullName, $gender = null)
 {
@@ -118,7 +118,7 @@ function detectGender($fullName)
  */
 function normalizeFullName($name)
 {
-    $name = preg_replace('~[ ]{2,}~', null, trim($name));
+    $name = preg_replace('~[ ]{2,}~', '', trim($name));
     return $name;
 }
 
@@ -139,6 +139,7 @@ function normalizeFullName($name)
 function pluralize($count, $word, $animateness = false, $case = null)
 {
     // меняем местами аргументы, если они переданы в старом формате
+    // @phpstan-ignore-next-line
     if (is_string($count) && is_numeric($word)) {
         list($count, $word) = [$word, $count];
     }

--- a/src/S.php
+++ b/src/S.php
@@ -1,6 +1,8 @@
 <?php
 namespace morphos;
 
+use RuntimeException;
+
 /**
  * Multibyte string helper
  */
@@ -9,6 +11,7 @@ class S
     /** @var string Encoding used for string manipulations */
     static protected $encoding;
 
+    /** @var string[][] */
     static protected $cyrillicAlphabet = [
         ['Ё', 'Й', 'Ц', 'У', 'К', 'Е', 'Н', 'Г', 'Ш', 'Щ', 'З', 'Х', 'Ъ', 'Ф', 'Ы', 'В', 'А', 'П', 'Р', 'О', 'Л', 'Д', 'Ж', 'Э', 'Я', 'Ч', 'С', 'М', 'И', 'Т', 'Ь', 'Б', 'Ю'],
         ['ё', 'й', 'ц', 'у', 'к', 'е', 'н', 'г', 'ш', 'щ', 'з', 'х', 'ъ', 'ф', 'ы', 'в', 'а', 'п', 'р', 'о', 'л', 'д', 'ж', 'э', 'я', 'ч', 'с', 'м', 'и', 'т', 'ь', 'б', 'ю'],
@@ -17,7 +20,7 @@ class S
     /**
      * Sets encoding for all operations
      * @param string $encoding
-     * @return bool
+     * @return void
      */
     public static function setEncoding($encoding)
     {
@@ -35,8 +38,8 @@ class S
 
     /**
      * Calculates count of characters in string.
-     * @param $string
-     * @return bool|int
+     * @param string $string
+     * @return int|false
      */
     public static function length($string)
     {
@@ -56,7 +59,7 @@ class S
      * @param string $string
      * @param int $start
      * @param int|null $end
-     * @return bool|string
+     * @return string
      */
     public static function slice($string, $start, $end = null)
     {
@@ -72,13 +75,13 @@ class S
             return iconv_substr($string, $start, $end ?: iconv_strlen($string), static::getEncoding());
         }
 
-        return false;
+        throw new RuntimeException('Unreachable');
     }
 
     /**
      * Lower case.
-     * @param $string
-     * @return bool|string
+     * @param string $string
+     * @return string
      */
     public static function lower($string)
     {
@@ -91,7 +94,7 @@ class S
 
     /**
      * Upper case.
-     * @param $string
+     * @param string $string
      * @return bool|string
      */
     public static function upper($string)
@@ -105,7 +108,7 @@ class S
 
     /**
      * Name case. (ex: Thomas, Lewis). Works properly with separated by '-' words
-     * @param $string
+     * @param string $string
      * @return bool|string
      */
     public static function name($string)
@@ -119,9 +122,9 @@ class S
 
     /**
      * multiple substr_count().
-     * @param $string
-     * @param array $chars
-     * @return bool|int
+     * @param string $string
+     * @param string[] $chars
+     * @return int
      */
     public static function countChars($string, array $chars)
     {
@@ -139,7 +142,7 @@ class S
     /**
      * @param string $string
      * @param string $char
-     * @return bool|string
+     * @return int|false
      */
     public static function findFirstPosition($string, $char)
     {
@@ -153,7 +156,7 @@ class S
     /**
      * @param string $string
      * @param string $char
-     * @return bool|string
+     * @return int|false
      */
     public static function findLastPosition($string, $char)
     {
@@ -165,9 +168,9 @@ class S
     }
 
     /**
-     * @param $string
-     * @param array $chars
-     * @return bool|string
+     * @param string $string
+     * @param string[] $chars
+     * @return string|false
      */
     public static function findLastPositionForOneOfChars($string, array $chars)
     {
@@ -190,11 +193,11 @@ class S
     }
 
     /**
-     * @param $string
-     * @param $substring
+     * @param string $string
+     * @param string $substring
      * @param bool $caseSensetive
      * @param int $startOffset
-     * @return string|false
+     * @return int|false
      */
     public static function indexOf($string, $substring, $caseSensetive = false, $startOffset = 0)
     {
@@ -208,9 +211,9 @@ class S
     }
 
     /**
-     * @param $string
-     * @param $fromMap
-     * @param $toMap
+     * @param string $string
+     * @param string[] $fromMap
+     * @param string[] $toMap
      * @return string
      */
     private static function replaceByMap($string, $fromMap, $toMap)

--- a/src/TimeSpeller.php
+++ b/src/TimeSpeller.php
@@ -4,6 +4,7 @@ namespace morphos;
 use DateInterval;
 use DateTime;
 use InvalidArgumentException;
+use RuntimeException;
 
 abstract class TimeSpeller
 {
@@ -26,11 +27,13 @@ abstract class TimeSpeller
 
     /**
      * @abstract
-     * @param $count
-     * @param $unit
+     * @param int $count
+     * @param string $unit
      * @return string
      */
-    public static function spellUnit($count, $unit) {}
+    public static function spellUnit($count, $unit) {
+        throw new RuntimeException('Not implemented');
+    }
 
     /**
      * @param DateInterval $interval

--- a/tests/Russian/AdjectiveDeclensionTest.php
+++ b/tests/Russian/AdjectiveDeclensionTest.php
@@ -11,7 +11,7 @@ class AdjectiveDeclensionTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider wordsProvider
      *
-     * @param $word
+     * @param string $word
      * @param $animateness
      * @param $inflected
      */

--- a/tests/Russian/AdjectivePluralizationTest.php
+++ b/tests/Russian/AdjectivePluralizationTest.php
@@ -12,7 +12,7 @@ class AdjectivePluralizationTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider wordsProvider
      *
-     * @param $word
+     * @param string $word
      * @param $animateness
      * @param $inflected
      */

--- a/tests/Russian/FunctionsTest.php
+++ b/tests/Russian/FunctionsTest.php
@@ -118,6 +118,7 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('21 небольшая лампа', \morphos\Russian\pluralize(21, 'небольшая лампа'));
 
         // old-style call to pluralize()
+        // @phpstan-ignore-next-line
         $this->assertEquals('10 сообщений', \morphos\Russian\pluralize('сообщение', 10));
     }
 

--- a/tests/Russian/NounPluralizationTest.php
+++ b/tests/Russian/NounPluralizationTest.php
@@ -10,7 +10,7 @@ class NounPluralizationTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider pluralizationWordsProvider
      *
-     * @param $word
+     * @param string $word
      * @param $pluralized2
      * @param $pluralized5
      *
@@ -72,11 +72,11 @@ class NounPluralizationTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider pluralizationWordsWithCaseProvider
      *
-     * @param $word
+     * @param string $word
      * @param $pluralizedOne
      * @param $pluralizedMany
      *
-     * @param $case
+     * @param string $case
      *
      * @throws \Exception
      */


### PR DESCRIPTION
This PR:
- [x] fixes lots of wrong/missing PHPDoc types
- [x] adds PHP 7.4 to test matrix
- [x] adds PHPStan CI pipeline to do a static code analysis
- [x] adds a small portion of SCA-specific type hints (like `array<string, string>` to show the key type or `array<\morphos\Cases::*>` to reference interface constants) to further improve code quality
- [x] fixes #88