### PR TITLE
Фикс склонения Кемерово

### DIFF
--- a/src/Russian/GeographicalNamesInflection.php
+++ b/src/Russian/GeographicalNamesInflection.php
@@ -40,7 +40,6 @@ class GeographicalNamesInflection extends \morphos\BaseInflection implements Cas
         'алматы',
         'сочи',
         'гоа',
-        'кемерово',
         'назарово',
         'иваново',
         // фикс для Марий Эл


### PR DESCRIPTION
Кемерово склоняется как слово среднего рода.
http://gramota.ru/class/istiny/istiny_1_toponimy/