### PR TITLE
Fix names with "Ы"

### DIFF
--- a/src/Russian/FirstNamesInflection.php
+++ b/src/Russian/FirstNamesInflection.php
@@ -249,8 +249,8 @@ class FirstNamesInflection extends \morphos\NamesInflection implements Cases
             return static::$exceptions[$name];
         } elseif (in_array(S::slice($name, -1), array_diff(static::$consonants, ['й', /*'Ч', 'Щ'*/]), true)) { // hard consonant
 			if (in_array(S::slice($name, -2), ['ек', 'ёк'], true)) { // Витек, Санек
-                // case for foreign names like Салмонбек
-                if (static::isConsonant(S::slice($name, -4, -3)))
+                // case for foreign names like Салмонбек and Абдыбек
+                if (static::isConsonant(S::slice($name, -4, -3)) || S::slice($name, -4, -3) === 'ы')
                     $prefix = S::name(S::slice($name, 0, -2)).'ек';
                 else
 				    $prefix = S::name(S::slice($name, 0, -2)).'ьк';


### PR DESCRIPTION
Fix for names like Абдыбек, because it transforms to Абдыбьку, where correct is Адыбеку