### PR TITLE
Added precalculated cases of cardinal number 8 in Russian\CardinalNumeralGenerator 

### DIFF
--- a/src/Russian/CardinalNumeralGenerator.php
+++ b/src/Russian/CardinalNumeralGenerator.php
@@ -139,6 +139,14 @@ class CardinalNumeralGenerator extends NumeralGenerator implements Cases
             self::TVORIT  => 'четырьмя',
             self::PREDLOJ => 'четырех',
         ],
+        'восемь'      => [
+            self::IMENIT  => 'восемь',
+            self::RODIT   => 'восьми',
+            self::DAT     => 'восьми',
+            self::VINIT   => 'восемь',
+            self::TVORIT  => 'восемью',
+            self::PREDLOJ => 'восьми',
+        ],
         'восемьдесят' => [
             self::IMENIT  => 'восемьдесят',
             self::RODIT   => 'восьмидесяти',

--- a/tests/Russian/CardinalNumeralTest.php
+++ b/tests/Russian/CardinalNumeralTest.php
@@ -29,6 +29,7 @@ class CardinalNumeralTest extends TestCase
         return [
             [1, NumeralGenerator::MALE, 'один', 'одного', 'одному', 'один', 'одним', 'одном'],
             [1, NumeralGenerator::FEMALE, 'одна', 'одной', 'одной', 'одну', 'одной', 'одной'],
+            [8, NumeralGenerator::MALE, 'восемь', 'восьми', 'восьми', 'восемь', 'восемью', 'восьми'],
             [
                 85,
                 NumeralGenerator::MALE,


### PR DESCRIPTION
Fix 'восеми' -> 'восьми' for genitive case (wrongly calculates by the ending of the word 'восемь' by default).