### PR TITLE
Removed precalculated cases for cardinal number 1000 in Russian\CardinalNumeralGenerator

### DIFF
--- a/src/Russian/CardinalNumeralGenerator.php
+++ b/src/Russian/CardinalNumeralGenerator.php
@@ -163,14 +163,6 @@ class CardinalNumeralGenerator extends NumeralGenerator implements Cases
             self::TVORIT  => 'восьмистами',
             self::PREDLOJ => 'восьмистах',
         ],
-        'тысяча'      => [
-            self::IMENIT  => 'тысяча',
-            self::RODIT   => 'тысяч',
-            self::DAT     => 'тысячам',
-            self::VINIT   => 'тысяч',
-            self::TVORIT  => 'тысячей',
-            self::PREDLOJ => 'тысячах',
-        ],
     ];
 
     /**

--- a/tests/Russian/CardinalNumeralTest.php
+++ b/tests/Russian/CardinalNumeralTest.php
@@ -60,6 +60,16 @@ class CardinalNumeralTest extends TestCase
                 'трехстах сорока четырех',
             ],
             [
+                1000,
+                NumeralGenerator::FEMALE,
+                'тысяча',
+                'тысячи',
+                'тысяче',
+                'тысячу',
+                'тысячей',
+                'тысяче',
+            ],
+            [
                 1007,
                 NumeralGenerator::MALE,
                 'одна тысяча семь',


### PR DESCRIPTION
Cases for word 'тысяча' now correctly generates by `morphos\Russian\NounDeclension::declinateFirstDeclension()`.
Also precalculated cases in `morphos\Russian\CardinalNumeralGenerator::$precalculated` for the word 'тысяча' was the mix of singular and plural forms, for example
```
self::TVORIT  => 'тысячей', // singular
self::PREDLOJ => 'тысячах', // plural
```
 which is not correct imho. 