### PR TITLE
Склонение мужских фамилий с окончаниями ок

### DIFF
--- a/src/Russian/LastNamesInflection.php
+++ b/src/Russian/LastNamesInflection.php
@@ -212,6 +212,19 @@ class LastNamesInflection extends \morphos\NamesInflection implements Cases
                     ];
                 }
 
+                if (S::length($name) > 3 && in_array(S::slice($name, -2), ['ок'], true)) {
+                    $prefix = S::name(S::slice($name, 0, -2)) . S::slice($name, -1);
+
+                    return [
+                        static::IMENIT => S::name($name),
+                        static::RODIT => $prefix . 'а',
+                        static::DAT => $prefix . 'у',
+                        static::VINIT => $prefix . 'а',
+                        static::TVORIT => $prefix . 'ом',
+                        static::PREDLOJ => $prefix . 'е',
+                    ];
+                }
+
             } else {
                 if (in_array(S::slice($name, -3), ['ова', 'ева', 'ина', 'ына', 'ёва'], true)) {
                     $prefix = S::name(S::slice($name, 0, -1));

--- a/tests/Russian/LastNamesInflectionTest.php
+++ b/tests/Russian/LastNamesInflectionTest.php
@@ -77,6 +77,9 @@ class LastNamesInflectionTest extends TestCase
             //            ['Зоя', NamesInflection::FEMALE, 'Зои', 'Зое', 'Зою', 'Зоей', 'Зое'],
             //            ['Молодыха', NamesInflection::FEMALE, 'Молодыхи', 'Молодыхе', 'Молодыху', 'Молодыхой', 'Молодыхе'],
             ['Стальная', NamesInflection::FEMALE, 'Стальной', 'Стальной', 'Стальную', 'Стальной', 'Стальной'],
+            ['Янушонок', NamesInflection::MALE, 'Янушонка', 'Янушонку', 'Янушонка', 'Янушонком', 'Янушонке'],
+            ['Оборок', NamesInflection::MALE, 'Оборка', 'Оборку', 'Оборка', 'Оборком', 'Оборке'],
+            ['Бок', NamesInflection::MALE, 'Бока', 'Боку', 'Бока', 'Боком', 'Боке'],
             [
                 'Завгородняя',
                 NamesInflection::FEMALE,


### PR DESCRIPTION
Пример
До

{  
    "original": "Янушонок Олег Иванович",  
    "Р": "Янушонока Олега Ивановича",  
    "Д": "Янушоноку Олегу Ивановичу",  
    "В": "Янушонока Олега Ивановича"  
},

После
{  
    "original": "Янушонок Олег Иванович",  
    "Р": "Янушонка Олега Ивановича",  
    "Д": "Янушонку Олегу Ивановичу",  
    "В": "Янушонка Олега Ивановича"  
},


Правило

https://gramota.ru/biblioteka/spravochniki/pismovnik/kak-sklonyat-familii-trudnye-sluchai - правило
цитата:
"Склонение ряда фамилий (как в единственном, так и во множественном числе) оказывается затруднительным из-за неясности, должна ли в них сохраняться беглость гласных по образцу омонимичных им или похожих по внешнему виду нарицательных существительных (Кравеца или Кравца — от Кравец, Журавеля или Журавля — от Журавель, Мазурока или Мазурка — от Мазурок и т. п.)."


Проверял тут
https://tamali.net/instrument/text/sklonenie-fio/
Библиотека [moprher](https://morpher.ru/php/extension/) выдает те же варианты