### PR TITLE
feat: Добавление бухгалтерского формата для денежных сумм

### DIFF
--- a/src/MoneySpeller.php
+++ b/src/MoneySpeller.php
@@ -10,6 +10,7 @@ abstract class MoneySpeller implements Currency
     const NORMAL_FORMAT        = 'normal';
     const CLARIFICATION_FORMAT = 'clarification';
     const DUPLICATION_FORMAT   = 'duplication';
+    const ACCOUNTING_FORMAT    = 'accounting';
 
     /**
      * @abstract

--- a/src/Russian/MoneySpeller.php
+++ b/src/Russian/MoneySpeller.php
@@ -100,6 +100,19 @@ class MoneySpeller extends \morphos\MoneySpeller
                             . NounPluralization::pluralize(static::$labels[$currency][2], $fractional, false, $case)
                         : null)
                     ;
+
+            case static::ACCOUNTING_FORMAT:
+                $integer_spelled = CardinalNumeralGenerator::getCase(
+                    $integer,
+                    $case !== null ? $case : Cases::IMENIT,
+                    static::$labels[$currency][1]);
+
+                return $integer_spelled . ' ' .
+                    NounPluralization::pluralize(static::$labels[$currency][0], $integer, false, $case) .
+                    ($fractional > 0 || $skipFractionalPartIfZero === false
+                        ? ' ' . $fractional . ' ' .
+                        NounPluralization::pluralize(static::$labels[$currency][2], $fractional, false, $case)
+                        : null);
         }
 
         throw new RuntimeException('Unreachable');

--- a/tests/Russian/MoneySpellerTest.php
+++ b/tests/Russian/MoneySpellerTest.php
@@ -81,6 +81,57 @@ class MoneySpellerTest extends TestCase
                     MoneySpeller::DUPLICATION_FORMAT,
                     'четыре миллиарда двести девяносто четыре миллиона девятьсот шестьдесят семь тысяч двести девяносто шесть (4294967296) рублей сорок (40) копеек',
                 ],
+                // Тесты для ACCOUNTING_FORMAT
+                [
+                    10000.25,
+                    Currency::RUBLE,
+                    MoneySpeller::ACCOUNTING_FORMAT,
+                    'десять тысяч рублей 25 копеек',
+                ],
+                [
+                    100.50,
+                    Currency::DOLLAR,
+                    MoneySpeller::ACCOUNTING_FORMAT,
+                    'сто долларов 50 центов',
+                ],
+                [
+                    200.30,
+                    Currency::EURO,
+                    MoneySpeller::ACCOUNTING_FORMAT,
+                    'двести евро 30 центов',
+                ],
+                [
+                    500,
+                    Currency::RUBLE,
+                    MoneySpeller::ACCOUNTING_FORMAT,
+                    'пятьсот рублей',
+                ],
+                [
+                    200.30,
+                    Currency::RUBLE,
+                    MoneySpeller::ACCOUNTING_FORMAT,
+                    'двухсот рублей 30 копеек',
+                    Cases::RODIT
+                ],
+                [
+                    300.45,
+                    Currency::RUBLE,
+                    MoneySpeller::ACCOUNTING_FORMAT,
+                    'тремстам рублям 45 копейкам',
+                    Cases::DAT
+                ],
+                [
+                    1000000.99,
+                    Currency::RUBLE,
+                    MoneySpeller::ACCOUNTING_FORMAT,
+                    'один миллион рублей 99 копеек',
+                ],
+                [
+                    500.50,
+                    Currency::HRYVNIA,
+                    MoneySpeller::ACCOUNTING_FORMAT,
+                    'пятьсот гривен 50 копеек',
+                ],
             ];
     }
 


### PR DESCRIPTION
## Добавление бухгалтерского формата для денежных сумм

Добавлен новый формат вывода денежных сумм для метода `MoneySpeller::spell()` - `ACCOUNTING_FORMAT`, который соответствует правилам оформления финансовых и бухгалтерских документов. В этом формате целая часть числа выводится прописью, а дробная - цифрами.

## Детали реализации

1. Добавлена новая константа `ACCOUNTING_FORMAT = 'accounting'` в класс `MoneySpeller`
2. В методе `spell()` добавлен обработчик для нового формата

## Примеры использования

```php
use morphos\Russian\MoneySpeller;
use morphos\Currency;
use morphos\Russian\Cases;

// Вывод: "десять тысяч рублей 25 копеек"
echo MoneySpeller::spell(10000.25, Currency::RUBLE, MoneySpeller::ACCOUNTING_FORMAT);

// С указанием падежа (родительный)
// Вывод: "двухсот рублей 30 копеек"
echo MoneySpeller::spell(200.30, Currency::RUBLE, MoneySpeller::ACCOUNTING_FORMAT, Cases::RODIT);
```

## Особенности нового формата

- Целая часть суммы выводится прописью согласно всем правилам русского языка
- Копейки (или центы, и т.д.) выводятся цифрами
- Поддерживаются все валюты, доступные в библиотеке
- Работает со всеми падежами русского языка

@wapmorgan  Этот PR решает эту проблему [https://github.com/wapmorgan/Morphos/issues/160](https://github.com/wapmorgan/Morphos/issues/160)