### PR TITLE
fix: PHP-8.1 deprecation "Implicit conversion from float to int loses precision"

### DIFF
--- a/src/Russian/NounPluralization.php
+++ b/src/Russian/NounPluralization.php
@@ -105,9 +105,9 @@ class NounPluralization extends \morphos\BasePluralization implements Cases
     public static function getNumeralForm($count)
     {
         if ($count > 100) {
-            $count %= 100;
+            $count = (int) $count % 100;
         }
-        $ending = $count % 10;
+        $ending = (int) $count % 10;
 
         if (($count > 20 && $ending == 1) || $count == 1) {
             return static::ONE;

--- a/tests/Russian/NounPluralizationTest.php
+++ b/tests/Russian/NounPluralizationTest.php
@@ -24,18 +24,21 @@ class NounPluralizationTest extends TestCase
         $this->assertEquals($word, NounPluralization::pluralize($word, 101));
         $this->assertEquals($word, NounPluralization::pluralize($word, 201));
         $this->assertEquals($word, NounPluralization::pluralize($word, 1501));
+        $this->assertEquals($word, NounPluralization::pluralize($word, 1.0));
 
         // Two-Four
         $this->assertEquals($pluralized2, NounPluralization::pluralize($word, 2));
         $this->assertEquals($pluralized2, NounPluralization::pluralize($word, 23));
         $this->assertEquals($pluralized2, NounPluralization::pluralize($word, 104));
         $this->assertEquals($pluralized2, NounPluralization::pluralize($word, 1503));
+        $this->assertEquals($pluralized2, NounPluralization::pluralize($word, 123.123));
 
         // Five
         $this->assertEquals($pluralized5, NounPluralization::pluralize($word, 5));
         $this->assertEquals($pluralized5, NounPluralization::pluralize($word, 211));
         $this->assertEquals($pluralized5, NounPluralization::pluralize($word, 520));
         $this->assertEquals($pluralized5, NounPluralization::pluralize($word, 1513));
+        $this->assertEquals($pluralized5, NounPluralization::pluralize($word, 10.5));
     }
 
     public function pluralizationWordsProvider()


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9388339a-6ad5-43fb-81c2-52bf57435283)
