### PR TITLE
Fix missing return statement in TWO_FOUR case

### DIFF
--- a/src/Russian/AdjectivePluralization.php
+++ b/src/Russian/AdjectivePluralization.php
@@ -34,7 +34,7 @@ class AdjectivePluralization extends BasePluralization implements Cases
                 case NounPluralization::ONE:
                     return $adjective;
                 case NounPluralization::TWO_FOUR:
-//                    return AdjectiveDeclension::getCase($adjective, static::RODIT, $animateness);
+                    return AdjectiveDeclension::getCase($adjective, static::RODIT, $animateness);
                 case NounPluralization::FIVE_OTHER:
                     return AdjectivePluralization::getCase($adjective, static::RODIT, $animateness);
             }


### PR DESCRIPTION
## Bug Description

In `AdjectivePluralization::pluralize()`, the `TWO_FOUR` case in the switch statement has no return statement (it was commented out), causing undefined behavior when count is 2, 3, or 4.

## Fix

Uncommented the return statement for the `TWO_FOUR` case that returns the genitive case form using `AdjectiveDeclension::getCase()`.

## Before
```php
case NounPluralization::TWO_FOUR:
//                    return AdjectiveDeclension::getCase($adjective, static::RODIT, $animateness);
```

## After
```php
case NounPluralization::TWO_FOUR:
                    return AdjectiveDeclension::getCase($adjective, static::RODIT, $animateness);
```

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.